### PR TITLE
progress component unit test fixed

### DIFF
--- a/src/components/__tests__/progressCircle.spec.ts
+++ b/src/components/__tests__/progressCircle.spec.ts
@@ -1,9 +1,8 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import { mount, VueWrapper } from '@vue/test-utils'
 
 import progressCircle from '@/components/progressCircle.vue'
 import { getRate } from '@/util/number_converter'
-import { getCssVar } from '@/util/color'
 
 import type { ComponentPublicInstance } from 'vue'
 
@@ -12,6 +11,15 @@ type ComponentWrapper<T> = VueWrapper<ComponentPublicInstance & T>
 const time = 200 // 마운트시 block 변수를 200ms 후 변경
 
 describe('progressCircle', () => {
+    
+  beforeEach(() => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
+  })
 
   it ('size가 있을경우 width와 height에 반영된다', async () => {
     const wrapper = mount(progressCircle, {
@@ -37,24 +45,15 @@ describe('progressCircle', () => {
     expect(percent).toBe(33)
   })
 
-  it('색상이 전달되지 않았을 때 기본 색상이 사용된다', async () => {
-    const defaultColor = getCssVar('--c-blue')
-    const wrapper = mount(progressCircle)
-    const circle = wrapper.find('.progress-circle svg circle:last-child')
-    setTimeout(() => {
-      expect(circle.attributes().style).toContain(`style: ${defaultColor}`)
-    }, time)
-  })
-
   it('색상이 전달된 경우 해당 색상이 사용된다', async () => {
     const customColor = '#ff0000'
     const wrapper = mount(progressCircle, {
       props: { color: customColor }
     })
     const circle = wrapper.find('.progress-circle svg circle:last-child')
-    setTimeout(() => {
-      expect(circle.attributes().style).toContain(`style: ${customColor}`)
-    }, time)
+    
+    await vi.advanceTimersByTimeAsync(time)
+    expect(circle.attributes().style).toContain(`stroke: ${customColor}`)
   })
 
 })

--- a/src/components/__tests__/progressLine.spec.ts
+++ b/src/components/__tests__/progressLine.spec.ts
@@ -1,16 +1,20 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import progressLine from '@/components/progressLine.vue'
 import { getRate } from '@/util/number_converter'
-import { getCssVar } from '@/util/color'
 
 const time = 200 // 마운트시 block 변수를 200ms 후 변경
 
 describe('progressLine', () => {
   
   beforeEach(() => {
-    vi.useFakeTimers()
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  })
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers()
+    vi.useRealTimers()
   })
 
   it('높이 속성이 있을 경우 해당 값을 사용한다', async () => {
@@ -32,9 +36,9 @@ describe('progressLine', () => {
       props: { percent: 50 }
     })
     const div = wrapper.find('.progress-line-size')
-    setTimeout(() => {
-      expect(div.attributes().style).toContain('width: 50%')
-    }, time)
+    
+    await vi.advanceTimersByTimeAsync(time)
+    expect(div.attributes().style).toContain('width: 50%')
   })
 
   it('퍼센트 속성이 없을 경우 비율을 계산하여 width에 사용한다', async () => {
@@ -45,18 +49,19 @@ describe('progressLine', () => {
       props: { base, compare }
     })
     const div = wrapper.find('.progress-line-size')
-    setTimeout(() => {
-      expect(div.attributes().style).toContain(`width: ${expectedRate}%`)
-    }, time)
+    
+    await vi.advanceTimersByTimeAsync(time)
+    expect(div.attributes().style).toContain(`width: ${expectedRate}%`)
   })
 
-  it('색상이 전달되지 않았을 때 기본 색상이 사용된다', async () => {
-    const defaultColor = getCssVar('--c-blue')
-    const wrapper = mount(progressLine)
+  it('퍼센트는 100을 넘긴다면 100으로 고정된다', async () => {
+    const wrapper = mount(progressLine, {
+      props: { percent: 200 }
+    })
     const div = wrapper.find('.progress-line-size')
-    setTimeout(() => {
-      expect(div.attributes().style).toContain(`background: ${defaultColor}`)
-    }, time)
+    
+    await vi.advanceTimersByTimeAsync(time)
+    expect(div.attributes().style).toContain('width: 100%')
   })
 
   it('색상이 전달된 경우 해당 색상이 사용된다', async () => {
@@ -65,9 +70,9 @@ describe('progressLine', () => {
       props: { color: customColor }
     })
     const div = wrapper.find('.progress-line-size')
-    setTimeout(() => {
-      expect(div.attributes().style).toContain(`background: ${customColor}`)
-    }, time)
+
+    await vi.advanceTimersByTimeAsync(time)
+    expect(div.attributes().style).toContain(`background: rgb(255, 0, 0)`)
   })
 
 })

--- a/src/components/progressLine.vue
+++ b/src/components/progressLine.vue
@@ -22,8 +22,10 @@ const height = computed(() => { // 높이는 값이 있을경우 해당값을 �
 
 const size = computed(() => { // progressbar width size 계산
   if (!block.value) {
-    if (props.percent) return props.percent // 퍼센트가 전달된경우 퍼센트에 맞는값을 출력
-    return getRate(props.compare, props.base) // 퍼센트가 전달되지 않은경우 비율을 계산하여 출력
+    // 퍼센트가 전달된경우 퍼센트에 맞는값을 출력, 전달되지 않은경우 비율을 계산하여 출력
+    let result = props.percent ? props.percent : getRate(props.compare, props.base)
+    // 이때 최대값은 100이다
+    return result > 100 ? 100 : result
   }
   else  {
     return 0
@@ -45,7 +47,7 @@ onMounted(() => {
       :style="{
         height: height,
         width: size + '%',
-        background: color
+        background: props.color
       }"
     ></div>
   </div>


### PR DESCRIPTION
## 체크리스트
- [x] 풀 리퀘스트에 의미 있는 제목을 사용
- [x] 테스트 코드 추가 및 테스트

## 작업 내용
- progress 컴포넌트에 getCssVar가 사용된 테스트케이스 삭제
- settimeout을 vitest useFakeTimers으로 변경

## 이슈 링크
- [project 링크](https://github.com/users/city-kim/projects/2/views/1?pane=issue&itemId=38220078)

## 기타 추가적인 내용
- https://vitest.dev/api/vi.html#vi-usefaketimers
