### PR TITLE
component numbers for numberExpression and remove percent to base, compare

### DIFF
--- a/src/components/Common/PercentWithIcon.vue
+++ b/src/components/Common/PercentWithIcon.vue
@@ -1,6 +1,7 @@
 <script lang="ts" setup>
 // 양수, 음수에따라 caret 아이콘 및 색상이 변경되는 퍼센트값을 출력한다
 import { computed } from 'vue'
+import { numberExpression } from '@/util/number_converter'
 
 import SvgIcon from '@/components/Common/SvgIcon.vue'
 const props = defineProps({
@@ -11,19 +12,20 @@ const props = defineProps({
   toFixed: Number
 })
 
-const percent = computed(() => props.percent) // 비율계산하기
+const percent = computed(() => Math.abs(props.percent)) // 비율계산하기
+
 </script>
 <template>
   <div
     class="component-percentage"
-    :class="[percent > 0 ? 'up' : 'down']"
+    :class="[props.percent > 0 ? 'up' : 'down']"
   >
     <SvgIcon
-      :name="percent > 0 ? 'caret_up_fill' : 'caret_down_fill'"
+      :name="props.percent > 0 ? 'caret_up_fill' : 'caret_down_fill'"
       width="1rem"
       height="1rem"
     ></SvgIcon>
-    <p>{{ props.toFixed ? Math.abs(percent).toFixed(props.toFixed) : Math.abs(percent) }}%</p>
+    <p>{{ numberExpression(percent, toFixed) }}%</p>
   </div>
 </template>
 <style lang="scss">

--- a/src/components/Common/ProgressLine.vue
+++ b/src/components/Common/ProgressLine.vue
@@ -2,6 +2,7 @@
 // div 영역에 색상이 들어있는 div를 출력하여 progress를 표현한다
 import { computed, ref, onMounted } from 'vue'
 import { getCssVar } from '@/util/color'
+
 const props = defineProps({
   height: String, // 높이 전달받지 못하면 min-height: 1rem
   percent: { // 퍼센트를 전달받으면 해당 퍼센트를 출력한다

--- a/src/components/__tests__/Common/PercentWithIcon.spec.ts
+++ b/src/components/__tests__/Common/PercentWithIcon.spec.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { mount } from '@vue/test-utils'
 
 import PercentWithIcon from '@/components/Common/PercentWithIcon.vue'
+import { numberExpression } from '@/util/number_converter'
 
 describe('PercentWithIcon', () => {
   
@@ -11,26 +12,39 @@ describe('PercentWithIcon', () => {
         percent: -50
       }
     })
-    expect(wrapper.text()).toBe('50%') 
+    expect(wrapper.text()).toContain(50) 
   })
 
   it('퍼센트가 소수점이 있는경우 소수점이 표시되는지 확인', async () => {
+    const percent = 25.123
     const wrapper = mount(PercentWithIcon, {
       props: {
         percent: 25.123
       }
     })
-    expect(wrapper.text()).toBe('25.123%')
+    expect(wrapper.text()).toContain(numberExpression(percent))
   })
   
   it('toFixed가 전달되면 해당 값 만큼만 표시하는지 확인', async () => {
+    const percent = 33.3333333
+    const toFixed = 1
     const wrapper = mount(PercentWithIcon, {
       props: {
         percent: 33.3333333,
         toFixed: 1,
       }
     })
-    expect(wrapper.text()).toBe('33.3%')
+    expect(wrapper.text()).toContain(numberExpression(percent, toFixed))
+  })
+
+  it('퍼센트가 크다면 콤마가 추가된 값으로 출력', async () => {
+    const percent = 100000000
+    const wrapper = mount(PercentWithIcon, {
+      props: {
+        percent: percent
+      }
+    })
+    expect(wrapper.text()).toContain(numberExpression(percent))
   })
 
 })

--- a/src/components/__tests__/Common/ProgressLine.spec.ts
+++ b/src/components/__tests__/Common/ProgressLine.spec.ts
@@ -25,7 +25,9 @@ describe('ProgressLine', () => {
   })
 
   it('높이 속성이 없을 경우 기본값 1rem을 사용한다', async () => {
-    const wrapper = mount(ProgressLine)
+    const wrapper = mount(ProgressLine, {
+      props: { percent: 50 }
+    })
     const div = wrapper.find('.progress-line-size')
     expect(div.attributes().style).toContain('height: 1rem')
   })

--- a/src/util/__test__/number_converter.spec.ts
+++ b/src/util/__test__/number_converter.spec.ts
@@ -1,12 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import { getPercent, getRate, decreaseByPercent } from '@/util/number_converter'
+import { getPercent, getRate, decreaseByPercent, numberExpression} from '@/util/number_converter'
 
 describe('getPercent', () => {
-  it('argument가 누락된 경우 0을 반환한다', () => {
-    expect(getPercent(100)).toBe(0)
-    expect(getPercent(undefined, 50)).toBe(0)
-    expect(getPercent()).toBe(0)
-  })
 
   it('from이 높은경우 감소된 수치를 반환', () => {
     expect(getPercent(100, 200)).toBe(-50) // 100에서 200으로 50% 감소
@@ -18,11 +13,6 @@ describe('getPercent', () => {
 })
 
 describe('getRate', () => {
-  it('argument가 누락된 경우 0을 반환한다', () => {
-    expect(getRate(50)).toBe(0)
-    expect(getRate(undefined, 100)).toBe(0)
-    expect(getRate()).toBe(0)
-  })
 
   it('대상이 되는 값과 총합이 있을경우 비율을 반환한다', () => {
     expect(getRate(25, 100)).toBe(25) // 대상이 25이고 총 100일경우 25% 차지
@@ -32,15 +22,29 @@ describe('getRate', () => {
 })
 
 describe('decreaseByPercent', () => {
-  it('argument가 누락된 경우 0을 반환한다', () => {
-    expect(decreaseByPercent(50)).toBe(0)
-    expect(decreaseByPercent(undefined, 100)).toBe(0)
-    expect(decreaseByPercent()).toBe(0)
-  })
 
   it('대상이 되는 값과 감소할 퍼센트가 있을경우 감소된 값을 반환한다', () => {
     expect(decreaseByPercent(100, 50)).toBe(50) // 100에서 50% 감소할 경우 50
     expect(decreaseByPercent(50, 10)).toBe(45) // 50에서 10% 감소할 경우 45
     expect(decreaseByPercent(10, 50)).toBe(5) // 10에서 50% 감소할 경우 5
+  })
+})
+
+describe('numberExpression', () => {
+  it ('전달되는 숫자가 999 이상인경우 콤마를 찍어서 반환한다', () => {
+    expect(numberExpression(1000.000)).toBe('1,000') // 1000은 콤마를 찍어서 반환
+    expect(numberExpression(100000000)).toBe('100,000,000') // 3자리마다 콤마를 찍어서 반환
+  })
+
+  it ('전달되는 숫자가 100 이하인경우 소수점 1자리까지 반환한다', () => {
+    expect(numberExpression(10.123, 1)).toBe('10.1')
+    expect(numberExpression(99.99999, 2)).toBe('100.00')
+    expect(numberExpression(1.111111111, 3)).toBe('1.111')
+  })
+
+  it ('그 외는 내림된 숫자를 반환한다', () => {
+    expect(numberExpression(100)).toBe('100')
+    expect(numberExpression(12.333)).toBe('12')
+    expect(numberExpression(999.999999)).toBe('999')
   })
 })

--- a/src/util/number_converter.ts
+++ b/src/util/number_converter.ts
@@ -2,10 +2,9 @@
  * from에서 to로 변하면 얼마나 증감한지 구하기
  * @param from number 비교할 대상
  * @param to number 비교될 값
- * @returns 전달된 값에 대한 비율 (값이 하나라도 없으면 0)
+ * @returns 전달된 값에 대한 비율
  */
-const getPercent = (from?: number, to?: number) => {
-  if (!from || !to) return 0
+const getPercent = (from: number, to: number) => {
   return Math.floor(((from - to) / to) * 100)
 }
 
@@ -13,10 +12,9 @@ const getPercent = (from?: number, to?: number) => {
  * count가 totalCount에서 몇프로를 차지하는지 구하기
  * @param count number 구할값
  * @param totalCount number 전체값
- * @returns 전달된 값에 대한 비율 (값이 하나라도 없으면 0)
+ * @returns 전달된 값에 대한 비율
  */
-const getRate = (count?: number, totalCount?: number) => {
-  if (!count || !totalCount) return 0
+const getRate = (count: number, totalCount: number) => {
   return Math.floor((count / totalCount) * 100)
 }
 
@@ -24,11 +22,25 @@ const getRate = (count?: number, totalCount?: number) => {
  * totalValue값에 decrease퍼센트 만큼 감소한 값을 구하기
  * @param totalValue number 전체 값
  * @param decrease number 감소시킬 퍼센트
- * @returns 전달된 전체 값에 대한 감소하고 남은 값 (값이 하나라도 없으면 0)
+ * @returns 전달된 전체 값에 대한 감소하고 남은 값
  */
-const decreaseByPercent  = (totalValue?: number, decrease?: number) => {
-  if (!decrease || !totalValue) return 0
+const decreaseByPercent  = (totalValue: number, decrease: number) => {
   return totalValue * (1 - decrease / 100)
 }
 
-export { getPercent, getRate, decreaseByPercent }
+/**
+ * 숫자가 세자리를 넘기면 콤마를 추가하고 fixed가 전달되면 소수점 자리수를 반환, 그 외는 Math.floor된 숫자를 반환한다
+ * @param value number
+ * @param fixed number 소수점 자릿수
+ * @returns string 000,000,000 or 000.0 or 000.(fixed)
+ */
+const numberExpression = (value: number, fixed?: number) => {
+  if (value >= 1000) {
+    return value.toString().replace(/\B(?=(\d{3})+(?!\d))/g, ',')
+  } else if (fixed) {
+    return value.toFixed(fixed)
+  }
+  return Math.floor(value).toString()
+}
+
+export { getPercent, getRate, decreaseByPercent, numberExpression }


### PR DESCRIPTION
## 체크리스트
- [x] 풀 리퀘스트에 의미 있는 제목을 사용
- [x] 테스트 코드 추가 및 테스트

## 작업 내용
- numberExpression으로 값을 출력 콤마, 소수점, Math.floor가 적용
- base와 compare로 컴포넌트에서 퍼센트를 출력
- number_converter의 agument를 필수값으로 변경

## 이슈 링크
- [project 링크](https://github.com/users/city-kim/projects/2/views/1?pane=issue&itemId=39205395)
