### PR TITLE
add chromatic, fixed chart registerables

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,13 +14,15 @@
     "lint": "eslint . --ext .vue,.js,.jsx,.cjs,.mjs,.ts,.tsx,.cts,.mts --fix --ignore-path .gitignore",
     "format": "prettier --write src/",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "chromatic": "npx chromatic --project-token=chpt_0537c5fdca9821d"
   },
   "dependencies": {
     "@storybook/preview-api": "^7.4.6",
     "@types/luxon": "^3.3.2",
     "chart.js": "^4.4.0",
     "chartjs-plugin-datalabels": "^2.2.0",
+    "chromatic": "^7.2.2",
     "luxon": "^3.4.3",
     "pinia": "^2.1.6",
     "vue": "^3.3.4",
@@ -62,5 +64,7 @@
     "vite": "^4.4.9",
     "vitest": "^0.34.4",
     "vue-tsc": "^1.8.13"
-  }
+  },
+  "readme": "ERROR: No README data found!",
+  "_id": "vue_report@0.0.0"
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ dependencies:
   chartjs-plugin-datalabels:
     specifier: ^2.2.0
     version: 2.2.0(chart.js@4.4.0)
+  chromatic:
+    specifier: ^7.2.2
+    version: 7.2.2
   luxon:
     specifier: ^3.4.3
     version: 3.4.3
@@ -4684,6 +4687,11 @@ packages:
     resolution: {integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==}
     engines: {node: '>=10'}
     dev: true
+
+  /chromatic@7.2.2:
+    resolution: {integrity: sha512-o9EIMV/EAe6bI7osYi4DfD1zuVovYR/vrY8CXNB5OdcT+alpHZmEZ4+ysTrvL9Bgk6zP/z/2YMVz5ZYdV/gagA==}
+    hasBin: true
+    dev: false
 
   /ci-info@3.8.0:
     resolution: {integrity: sha512-eXTggHWSooYhq49F2opQhuHWgzucfF2YgODK4e1566GQs5BIfP30B0oenwBJHfWxAs2fyPB1s7Mg949zLf61Yw==}

--- a/src/components/Common/Chart/BarChart.vue
+++ b/src/components/Common/Chart/BarChart.vue
@@ -1,21 +1,13 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import {
-  Chart as ChartJS,
-  Title,
-  Tooltip,
-  Legend,
-  BarElement,
-  CategoryScale,
-  LinearScale
-} from 'chart.js'
+import { Chart as ChartJS, registerables} from 'chart.js'
 import { Bar } from 'vue-chartjs'
 import { WITH_GUIDE, WITHOUT_GUIDE } from '@/constants/components/CHART_OPTIONS'
 
 import type { PropType } from 'vue'
 import type { BarChartData } from '@/types/components/chart'
 
-ChartJS.register(CategoryScale, LinearScale, BarElement, Title, Tooltip, Legend)
+ChartJS.register(...registerables)
 
 const props = defineProps({
   data: {

--- a/src/components/Common/Chart/LineChart.vue
+++ b/src/components/Common/Chart/LineChart.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { ref, onMounted, computed } from 'vue'
-import { Chart as ChartJS, CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler } from 'chart.js'
+import { Chart as ChartJS, registerables } from 'chart.js'
 import { Chart } from 'vue-chartjs'
 import { hexToRGBA } from '@/util/text_converter'
 import { WITH_GUIDE, WITHOUT_GUIDE } from '@/constants/components/CHART_OPTIONS'
@@ -10,7 +10,7 @@ import type { InteractionMode } from 'chart.js'
 import type { ChartComponentRef } from 'vue-chartjs'
 import type { LineChartData } from '@/types/components/chart'
 
-ChartJS.register(CategoryScale, LinearScale, PointElement, LineElement, Title, Tooltip, Legend, Filler)
+ChartJS.register(...registerables)
 
 ChartJS.defaults.elements.point.radius = 0 // default 반지름
 ChartJS.defaults.elements.point.hoverBorderWidth = 3 // hover시 border width

--- a/src/components/Common/Chart/PieChart.vue
+++ b/src/components/Common/Chart/PieChart.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import { computed } from 'vue'
-import { Chart as ChartJS, ArcElement, Tooltip, Legend } from 'chart.js'
+import { Chart as ChartJS, registerables} from 'chart.js'
 import { Chart } from 'vue-chartjs'
 import ChartDataLabels from 'chartjs-plugin-datalabels'
 import { WITH_GUIDE, WITHOUT_GUIDE } from '@/constants/components/CHART_OPTIONS'
@@ -8,7 +8,7 @@ import { WITH_GUIDE, WITHOUT_GUIDE } from '@/constants/components/CHART_OPTIONS'
 import type { PropType } from 'vue'
 import type { PieChartData } from '@/types/components/chart'
 
-ChartJS.register(ArcElement, Tooltip, Legend, ChartDataLabels)
+ChartJS.register(...registerables, ChartDataLabels)
 
 const props = defineProps({
   data: {

--- a/src/views/DashBoard/ProductInfo.vue
+++ b/src/views/DashBoard/ProductInfo.vue
@@ -77,8 +77,6 @@ onMounted(() => {
       </article>
       <article>
         <h3>종류별 비율</h3>
-        {{ product.categoryChart.labels }}
-        {{ PieChartDataset }}
         <PieChart
           :data="{
             labels: product.categoryChart.labels,


### PR DESCRIPTION
## 체크리스트
- [x] 풀 리퀘스트에 의미 있는 제목을 사용
- [x] 테스트 코드 추가 및 테스트

## 작업 내용
- chromatic 빌드시 chart의 register오류가 발생하여 차트의 register를 registerables로 변경
- DashBoard의 ProductInfo에 test로 출력하던 내용이 삭제되지 않은 것 수정

## 이슈 링크
- [project 링크](https://github.com/users/city-kim/projects/2/views/1?pane=issue&itemId=40696914)
